### PR TITLE
Error: HDPI setting moved to non-android targets

### DIFF
--- a/src/pokerth.cpp
+++ b/src/pokerth.cpp
@@ -100,10 +100,10 @@ int main( int argc, char **argv )
 
 	/////// can be removed for non-qt-guis ////////////
 #ifdef ANDROID
-	QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 	QApplication a(argc, argv);
 	a.setApplicationName("PokerTH");
 #else
+	QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 	SharedTools::QtSingleApplication a( "PokerTH", argc, argv );
 	if (a.sendMessage("Wake up!")) {
 		return 0;


### PR DESCRIPTION
Last commit had a mistake: It enabled HDPI support on android architecture, which is wrong. It should be enabled for non-android architectures. This commit corrects it. 